### PR TITLE
[Rails5.2] Fix MoveAwxCredentialsToAuthentications

### DIFF
--- a/manageiq-schema.gemspec
+++ b/manageiq-schema.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "more_core_extensions", "~> 3.5"
   s.add_dependency "pg"
   s.add_dependency "pg-pglogical", "~> 2.1.1"
-  s.add_dependency "rails", ">= 5.0.7.1", "!= 5.1.6.x", "< 5.2"
+  s.add_dependency "rails", "~>5.2.4"
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "rspec"

--- a/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
+++ b/spec/migrations/20190617191109_move_awx_credentials_to_authentications_spec.rb
@@ -272,7 +272,7 @@ describe MoveAwxCredentialsToAuthentications do
         end
 
         it "fails to migrate real data and fails with an error" do
-          expect { migrate }.to raise_error(described_class::Fernet256::InvalidToken)
+          expect { migrate }.to raise_error(StandardError, /#{described_class::Fernet256::InvalidToken.to_s}/)
         end
 
         context "with $HARDCODE_ANSIBLE_PASSWORD set 'bogus'" do


### PR DESCRIPTION
Fixes spec failure do to a change in Rails that wraps all migrations errors in `StandardError`.

We still try to check for the nested error by reading the `msg` (via the Regexp in the second argument)